### PR TITLE
Add missing chromium@edge dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk update && apk upgrade && \
   apk add --no-cache \
   chromium@edge \
   nss@edge \
+  harfbuzz@edge \
+  freetype@edge \
   ttf-freefont
 
 RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \


### PR DESCRIPTION
Looks like the latest chromium@edge version requires some more
dependencies to work - add harfbuzz@edge and freetype@edge.